### PR TITLE
Fixed Python 3 and latest SCons compatibility, supporting NVDA 2019.3+

### DIFF
--- a/buildVars.py
+++ b/buildVars.py
@@ -27,7 +27,7 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0")
-	"addon_minimumNVDAVersion" : "2019.3.0",
+	"addon_minimumNVDAVersion" : "2017.2.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
 	"addon_lastTestedNVDAVersion" : "2019.3.1",
 	# Add-on update channel (default is stable or None)

--- a/buildVars.py
+++ b/buildVars.py
@@ -19,7 +19,7 @@ addon_info = {
 	# Translators: Long description to be shown for this add-on on add-on information from add-ons manager
 	"addon_description" : _("""announces the number of words, characters, paragraphs and lines of the selected text when you select some text and press Control+Shift+F12. In some aplications, like Word, WordPad and DSpeech, it only announces word and characters, to avoid hanging NVDA."""),
 	# version
-	"addon_version" : "1.4",
+	"addon_version" : "1.5",
 	# Author(s)
 	"addon_author" : "Rui Fontes <rui.fontes@tiflotecnia.com>",
 	# URL for the add-on documentation support
@@ -27,9 +27,9 @@ addon_info = {
 	# Documentation file name
 	"addon_docFileName" : "readme.html",
 	# Minimum NVDA version supported (e.g. "2018.3.0")
-	"addon_minimumNVDAVersion" : "2017.2.0",
+	"addon_minimumNVDAVersion" : "2019.3.0",
 	# Last NVDA version supported/tested (e.g. "2018.4.0", ideally more recent than minimum version)
-	"addon_lastTestedNVDAVersion" : "2019.1.0",
+	"addon_lastTestedNVDAVersion" : "2019.3.1",
 	# Add-on update channel (default is stable or None)
 	"addon_updateChannel" : None,
 }

--- a/sconstruct
+++ b/sconstruct
@@ -21,7 +21,7 @@ def md2html(source, dest):
 	}
 	with codecs.open(source, "r", "utf-8") as f:
 		mdText = f.read()
-		for k, v in headerDic.iteritems():
+		for k, v in headerDic.items():
 			mdText = mdText.replace(k, v, 1)
 		htmlText = markdown.markdown(mdText)
 	with codecs.open(dest, "w", "utf-8") as f:
@@ -127,7 +127,7 @@ def generateManifest(source, dest):
 		f.write(manifest)
 
 def generateTranslatedManifest(source, language, out):
-	_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).ugettext
+	_ = gettext.translation("nvda", localedir=os.path.join("addon", "locale"), languages=[language]).gettext
 	vars = {}
 	for var in ("addon_summary", "addon_description"):
 		vars[var] = _(buildVars.addon_info[var])


### PR DESCRIPTION
After these changes, successfully built on Python v3.7.5 / SCons v3.1.2; launched and tested on NVDA v2019.3.1.